### PR TITLE
Update Quake.sh - add wildcards around "ArkOS" string test

### DIFF
--- a/ports/quake/Quake.sh
+++ b/ports/quake/Quake.sh
@@ -23,7 +23,7 @@ if [[ $CFW_NAME == "TheRA" ]]; then
 elif [[ $CFW_NAME == "RetroOZ" ]]; then
   raloc="/opt/retroarch/bin"
   raconf="--config /home/odroid/.config/retroarch/retroarch.cfg"
-elif [[ $CFW_NAME == "ArkOS" ]]; then
+elif [[ $CFW_NAME == *"ArkOS"* ]]; then
   raloc="/usr/local/bin"
   raconf=""
 elif [[ $CFW_NAME == "muOS" ]]; then


### PR DESCRIPTION
This allows Quake.sh to work on https://github.com/AeolusUX/ArkOS-R3XS which identifies as CFW_NAME="ArkOS AeUX"

# New Port for { Game Title }

## Game Information
- **Quake**: { Game Title }
- **URL**: { Link to project page or source control page }

## Submission Requirements

### CFW Tests
Ensure your game has been tested on all major CFWs:
- [ ] AmberELEC
- [ ] ArkOS
- [ ] ROCKNIX
- [ ] muOS

### Resolution Tests
Test all major resolutions:
- [ ] 480x320
- [ ] 640x480
- [ ] 720x720 (RGB30)
- [ ] Higher resolutions (e.g., 1280x720)

## File Structure
- Your port should have the following structure:
  - portname/
    - port.json
    - README.md
    - screenshot.jpg
    - cover.jpg
    - gameinfo.xml
    - Port Name.sh
    - portname/
      - <portfiles here>

## Additional Resources
For an in-depth guide on creating a pull request, refer to: [PortMaster Game Packaging Guide](https://portmaster.games/packaging.html#creating-a-pull-request)
